### PR TITLE
쿼리 파라미터로 reportId 받기 기능 추가 및 보고서 데이터 로드 로직 개선

### DIFF
--- a/src/components/weekly-report/WeeklyReport.css
+++ b/src/components/weekly-report/WeeklyReport.css
@@ -24,7 +24,7 @@
 
 .disabled-box, .enabled-box {
     width: 400px;
-    height: 650px;
+    height: 600px;
     border-radius: 10px;
     display: flex;
     flex-direction: column;
@@ -33,6 +33,7 @@
     text-align: center;
     padding: 20px;
     margin-top: 15px;
+    margin-left: 25px;
 }
 
 .disabled-box {

--- a/src/components/weekly-report/WeeklyReport.jsx
+++ b/src/components/weekly-report/WeeklyReport.jsx
@@ -1,23 +1,23 @@
 import './WeeklyReport.css';
 import KakaoMap from "../kakao-map/KakaoMap";
 import ProgressBar from "../ProgressBar/ProgressBar";
-import React, { useEffect, useState } from "react";
-import axios from 'axios'; // axios 사용
-import { REPORT_CHILD_ALL_REPORT, REPORT_CHILD_REPORT } from '../../routes/ApiPath.js';
-import prev from '../../assets/img/prev-button.png';
-import next from '../../assets/img/next-button.png';
+import React, { useContext, useEffect, useState } from "react";
+import axios from 'axios';
+import { REPORT_CHILD_ALL_REPORT, REPORT_UPDATE } from '../../routes/ApiPath.js';
+import AppContext from "../../contexts/AppProvider.jsx";
+import {useLocation, useNavigate} from 'react-router-dom';
+import {PATHS} from "../../routes/paths.js"; // useLocation 훅을 사용하여 쿼리 파라미터 받기
 
 // 주간 날짜 범위 계산 함수
 const getWeekRange = (date) => {
-    const dayOfWeek = date.getDay(); // 일요일=0, 월요일=1, ..., 토요일=6
-    const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek; // 일요일이면 -6, 월요일이면 1, ...
+    const dayOfWeek = date.getDay();
+    const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
     const startOfWeek = new Date(date);
-    startOfWeek.setDate(date.getDate() + diffToMonday); // 월요일 날짜 구하기
+    startOfWeek.setDate(date.getDate() + diffToMonday);
 
     const endOfWeek = new Date(startOfWeek);
-    endOfWeek.setDate(startOfWeek.getDate() + 6); // 일요일 날짜 구하기
+    endOfWeek.setDate(startOfWeek.getDate() + 6);
 
-    // 형식화된 날짜 (YYYY.MM.DD 형식으로 반환)
     const formatDate = (date) => {
         const year = date.getFullYear();
         const month = (date.getMonth() + 1).toString().padStart(2, '0');
@@ -37,51 +37,52 @@ const getDayName = (date) => {
 };
 
 const WeeklyReport = () => {
-    const [isAvailable, setIsAvailable] = useState(true); // 가용성 상태 (월요일 9시 이전엔 비활성화)
-    const [isDataAvailable, setIsDataAvailable] = useState(true); // 데이터 가용성 상태
-    const [selectedReport, setSelectedReport] = useState(null); // 선택된 보고서 상태
-    const [reports, setReports] = useState([]); // 보고서 리스트 상태
-    const [weekRange, setWeekRange] = useState(""); // 주간 날짜 범위 상태
-    const [currentReportIndex, setCurrentReportIndex] = useState(null); // 현재 선택된 보고서 인덱스
-    const childId = 56; // 예시 childId (실제로는 부모 컴포넌트에서 이 값을 전달하거나 컨텍스트로 관리할 수 있음)
+    const { selectedChildId } = useContext(AppContext);
+    const [isAvailable, setIsAvailable] = useState(true);
+    const [isDataAvailable, setIsDataAvailable] = useState(true);
+    const [isReadAvailable, setIsReadAvailable] = useState(true);
+    const [selectedReport, setSelectedReport] = useState(null);
+    const [reports, setReports] = useState([]);
+    const [weekRange, setWeekRange] = useState("");
+    const [currentReportIndex, setCurrentReportIndex] = useState(null);
+    const navigate = useNavigate(); // 페이지 이동을 위한 useNavigate 훅
+    const location = useLocation();  // location 객체를 사용하여 쿼리 파라미터를 읽기
+    const reportIdFromQuery = new URLSearchParams(location.search).get('reportId'); // URL에서 reportId 추출
+    console.log("reportIdFromQuery in Review:", reportIdFromQuery); // 쿼리 파라미터로 전달된 reportId 확인
+    // URL의 쿼리 파라미터에서 reportId를 추출하는 함수
 
-    // 월요일 오전 9시 이후인지 체크하는 함수
-    const checkIfAvailable = () => {
-        const now = new Date();
-        const dayOfWeek = now.getDay();
-        const hour = now.getHours();
-        if (dayOfWeek === 1 && hour >= 9) {
-            setIsAvailable(true); // 월요일 9시 이후
-        } else if (dayOfWeek > 1 || (dayOfWeek === 1 && hour < 9)) {
-            setIsAvailable(false); // 월요일 9시 전이나 다른 요일
-        }
-    };
 
     useEffect(() => {
-        checkIfAvailable(); // 월요일 9시 여부 확인
-
-        // 데이터가 없을 때, getAllReports API 호출하여 데이터 불러오기
         const fetchReports = async () => {
             try {
-                const response = await axios.get(`${REPORT_CHILD_ALL_REPORT}/${childId}`);
-                console.log("response.data:", response.data); // 응답 데이터 전체를 확인합니다.
+                const response = await axios.get(`${REPORT_CHILD_ALL_REPORT}/${selectedChildId}`);
+                console.log("response.data:", response.data);
 
                 if (Array.isArray(response.data) && response.data.length > 0) {
-                    console.log("reports:", response.data); // 실제 reports 배열 내용 확인
-
-                    // reports를 상태에 설정하고, 최신 보고서부터 역순으로 정렬
                     const sortedReports = response.data.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
                     setReports(sortedReports);
 
-                    // 가장 최신 보고서를 선택
-                    const latestReport = sortedReports[0];
-                    setSelectedReport(latestReport);
-                    setCurrentReportIndex(0); // 현재 선택된 보고서 인덱스 설정
+                    let selected = null;
+                    if (reportIdFromQuery) {
+                        const reportIdInt = parseInt(reportIdFromQuery, 10);
+                        selected = sortedReports.find(report => report.reportId === reportIdInt);
+                    }
 
-                    // 주간 날짜 범위 계산 및 설정
-                    const createdAt = new Date(latestReport.createdAt);
+                    if (!selected) {
+                        // 쿼리 파라미터에 맞는 보고서가 없으면 가장 최근 보고서 선택
+                        selected = sortedReports[0];
+                    }
+
+                    setSelectedReport(selected);
+                    setCurrentReportIndex(sortedReports.indexOf(selected));
+
+                    const createdAt = new Date(selected.createdAt);
                     const { start, end } = getWeekRange(createdAt);
                     setWeekRange(`${createdAt.getFullYear()}년 ${createdAt.getMonth() + 1}월 <br/> ${start} (${getDayName(new Date(start))}) ~ ${end} (${getDayName(new Date(end))})`);
+
+                    // 마지막에 isReadAvailable 설정 (selectedReport가 확실히 설정된 후에)
+                    setIsReadAvailable(selected.read);
+                    setIsDataAvailable(true);
                 } else {
                     console.error("보고서가 없습니다.");
                     setIsDataAvailable(false);
@@ -92,51 +93,51 @@ const WeeklyReport = () => {
             }
         };
 
-        fetchReports(); // 컴포넌트 마운트 시에 데이터 불러오기
-    }, [childId]);
+        fetchReports();
+    }, [selectedChildId, reportIdFromQuery]);
 
-    // 선택된 보고서를 불러오는 함수
-    const fetchReportById = async (reportId) => {
-        try {
-            const response = await axios.get(`${REPORT_CHILD_REPORT}/${reportId}`);
-            setSelectedReport(response.data); // 선택된 보고서 데이터 설정
-        } catch (error) {
-            console.error("보고서를 불러오는 데 실패했습니다:", error);
+    const handleReportChange = (direction) => {
+        const newIndex = currentReportIndex + direction;
+        if (newIndex >= 0 && newIndex < reports.length) {
+            setCurrentReportIndex(newIndex);
+            const newReport = reports[newIndex];
+            setSelectedReport(newReport);
+            setIsReadAvailable(newReport.read);
+
+            const createdAt = new Date(newReport.createdAt);
+            const { start, end } = getWeekRange(createdAt);
+            setWeekRange(`${createdAt.getFullYear()}년 ${createdAt.getMonth() + 1}월 <br/> ${start} (${getDayName(new Date(start))}) ~ ${end} (${getDayName(new Date(end))})`);
         }
     };
 
-    // 이전 보고서로 이동하는 함수
     const loadPreviousReport = () => {
-        if (currentReportIndex < reports.length - 1) { // 현재 보고서보다 과거 보고서로 이동
-            const previousReport = reports[currentReportIndex + 1];
-            setSelectedReport(previousReport); // 이전 보고서로 업데이트
-            setCurrentReportIndex(currentReportIndex + 1); // 인덱스 업데이트
-
-            // 이전 보고서 기준으로 주간 범위 업데이트
-            const createdAt = new Date(previousReport.createdAt);
-            const { start, end } = getWeekRange(createdAt);
-            setWeekRange(`${createdAt.getFullYear()}년 ${createdAt.getMonth() + 1}월 <br/> ${start} (${getDayName(new Date(start))}) ~ ${end} (${getDayName(new Date(end))})`);
+        if (currentReportIndex < reports.length - 1) {
+            handleReportChange(1);
         }
     };
 
-    // 다음 보고서로 이동하는 함수
     const loadNextReport = () => {
-        if (currentReportIndex > 0) { // 현재 보고서보다 최신 보고서로 이동
-            const nextReport = reports[currentReportIndex - 1];
-            setSelectedReport(nextReport); // 다음 보고서로 업데이트
-            setCurrentReportIndex(currentReportIndex - 1); // 인덱스 업데이트
-
-            // 다음 보고서 기준으로 주간 범위 업데이트
-            const createdAt = new Date(nextReport.createdAt);
-            const { start, end } = getWeekRange(createdAt);
-            setWeekRange(`${createdAt.getFullYear()}년 ${createdAt.getMonth() + 1}월 <br/> ${start} (${getDayName(new Date(start))}) ~ ${end} (${getDayName(new Date(end))})`);
+        if (currentReportIndex > 0) {
+            handleReportChange(-1);
         }
     };
 
-    // 리뷰 시작 버튼 클릭 시 실행되는 함수
-    const startReview = () => {
-        window.location.href = "/weeklyreview"; // 리뷰 페이지로 이동
+    const startReview = async () => {
+        try {
+            if (selectedReport) {
+                const updatedReport = {
+                    ...selectedReport,
+                    read: true
+                };
+
+                await axios.put(`${REPORT_UPDATE}/${selectedReport.reportId}`, updatedReport);
+                navigate(`${PATHS.WEEKLY_REPORT.REVIEW}?reportId=${selectedReport.reportId}`); // 쿼리 파라미터로 reportId 전달
+            }
+        } catch (error) {
+            console.error("보고서 읽음 상태 업데이트 실패:", error);
+        }
     };
+
 
     return (
         <>
@@ -145,9 +146,9 @@ const WeeklyReport = () => {
                 <button
                     className="previous-week-button"
                     onClick={loadPreviousReport}
-                    style={{ visibility: currentReportIndex < reports.length - 1 ? 'visible' : 'hidden' }}
+                    style={{visibility: currentReportIndex < reports.length - 1 ? 'visible' : 'hidden'}}
                 >
-                    <img src={prev} style={{ width: '38px', height: '30px' }} alt="prev" />
+                    <i className="bi bi-chevron-left"></i>
                 </button>
 
                 <div className="date-range" dangerouslySetInnerHTML={{ __html: weekRange }}></div> {/* 동적으로 계산된 주간 날짜 범위 */}
@@ -156,72 +157,72 @@ const WeeklyReport = () => {
                 <button
                     className="next-week-button"
                     onClick={loadNextReport}
-                    style={{ visibility: currentReportIndex > 0 ? 'visible' : 'hidden' }}
+                    style={{visibility: currentReportIndex > 0 ? 'visible' : 'hidden'}}
                 >
-                    <img src={next} style={{ width: '38px', height: '30px' }} alt="next" />
+                    <i className="bi bi-chevron-right"></i>
                 </button>
             </div>
 
             {/* 데이터가 없으면 review-box를 보여주고, 그렇지 않으면 기존의 report-content 등을 보여줌 */}
-            {isDataAvailable ? (
-                <div>
-                    <div className="report-content">
-                        {/* 피드백이 있으면 해당 피드백을 표시 */}
-                        {selectedReport ? selectedReport.feedback : "피드백을 불러오는 중입니다..."}
+            {!isReadAvailable ? (
+                <div className="enabled-box">
+                    <div className="icon-container">
+                        <dotlottie-player
+                            src="https://lottie.host/714f7cda-7a3d-47fa-8296-caf5ae946051/Sh7fIYjs1a.json"
+                            background="transparent"
+                            speed="1.5"
+                            className="lottie-player-before"
+                            autoplay
+                            loop={false}
+                        ></dotlottie-player>
                     </div>
-
-                    <div className="analysis-section">
-                        <h3>일기 분석 결과 위험성 정도</h3>
-                        <div className="progress-bar">
-                            <div className="low-risk"></div>
-                            <div className="high-risk"></div>
-                            {/* ProgressBar에 riskLevel * 20 값을 전달 */}
-                            {selectedReport ? (
-                                <ProgressBar value={selectedReport.riskLevel * 20} />
-                            ) : (
-                                <ProgressBar value={0} /> // 데이터가 없을 때는 0으로 기본값 설정
-                            )}
-                        </div>
-
-                        <h3>영상분석 결과 위험성 정도</h3>
-                        <div className="progress-bar">
-                            <div className="low-risk"></div>
-                            <div className="high-risk" style={{ width: '20%' }}></div>
-                            <ProgressBar value={30} />
-                        </div>
-                    </div>
-
-                    <div className="map-section">
-                        <h3>근처 병원 정보</h3>
-                        <KakaoMap />
-                    </div>
+                    <p className="text">지난주에 작성하신 일기에 대해 <br /> AI 분석을 실시해보세요.</p>
+                    <button className="generate-button" onClick={startReview}>AI 주간보고 생성</button>
                 </div>
             ) : (
-                <div className="review-box">
-                    {!isAvailable ? (
+                !isAvailable ? (
+                    <div className="review-box">
                         <div className="disabled-box">
                             <div className="icon-container">
                                 <span className="clock-icon" role="img" aria-label="Clock">🕒</span>
                             </div>
                             <p className="text">AI 주간보고 생성은 <br /> 매주 월요일 9시부터 가능합니다.</p>
                         </div>
-                    ) : (
-                        <div className="enabled-box">
-                            <div className="icon-container">
-                                <dotlottie-player
-                                    src="https://lottie.host/714f7cda-7a3d-47fa-8296-caf5ae946051/Sh7fIYjs1a.json"
-                                    background="transparent"
-                                    speed="1.5"
-                                    className="lottie-player-before"
-                                    autoplay
-                                    loop={false}
-                                ></dotlottie-player>
+                    </div>
+                ) : (
+                    isDataAvailable && (
+                        <div>
+                            <div className="report-content">
+                                {selectedReport ? selectedReport.feedback : "피드백을 불러오는 중입니다..."}
                             </div>
-                            <p className="text">지난주에 작성하신 일기에 대해 <br /> AI 분석을 실시해보세요.</p>
-                            <button className="generate-button" onClick={startReview}>AI 주간보고 생성</button>
+
+                            <div className="analysis-section">
+                                <h3>일기 분석 결과 위험성 정도</h3>
+                                <div className="progress-bar">
+                                    <div className="low-risk"></div>
+                                    <div className="high-risk"></div>
+                                    {selectedReport ? (
+                                        <ProgressBar value={selectedReport.riskLevel * 20} />
+                                    ) : (
+                                        <ProgressBar value={0} />
+                                    )}
+                                </div>
+
+                                <h3>영상분석 결과 위험성 정도</h3>
+                                <div className="progress-bar">
+                                    <div className="low-risk"></div>
+                                    <div className="high-risk" style={{ width: '20%' }}></div>
+                                    <ProgressBar value={30} />
+                                </div>
+                            </div>
+
+                            <div className="map-section">
+                                <h3>근처 병원 정보</h3>
+                                <KakaoMap />
+                            </div>
                         </div>
-                    )}
-                </div>
+                    )
+                )
             )}
         </>
     );

--- a/src/components/weekly-report/WeeklyReview.css
+++ b/src/components/weekly-report/WeeklyReview.css
@@ -72,7 +72,7 @@
     padding-top: 7px;
     padding-right: 3px;
     opacity: 0; /* 기본 opacity는 0 */
-    transition: opacity 0.5s ease-out; /* 1초 후에 서서히 나타남 */
+    transition: opacity 1s ease-out; /* 1초 후에 서서히 나타남 */
 }
 
 /* visible 상태일 때 */

--- a/src/components/weekly-report/WeeklyReview.jsx
+++ b/src/components/weekly-report/WeeklyReview.jsx
@@ -1,9 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React, {useState, useEffect, useContext} from 'react';
 import './WeeklyReview.css';
+import {PATHS} from "../../routes/paths.js";
+import {useNavigate} from "react-router-dom";
+
 
 const WeeklyReview = () => {
     const [isLoading, setIsLoading] = useState(true); // 처음에 isLoading을 true로 설정
     const [isVisible, setIsVisible] = useState(false); // 분석 완료 후 이미지 표시 여부 상태
+    const navigate = useNavigate();
+    const urlParams = new URLSearchParams(location.search);
+    const reportId = urlParams.get("reportId");
 
     // 외부 스크립트 로드 (dotlottie)
     useEffect(() => {
@@ -26,7 +32,7 @@ const WeeklyReview = () => {
     }, []); // 빈 배열을 사용하여 컴포넌트 마운트 시에만 실행
 
     const handleClick = () => {
-        window.location.href = '/weeklyreport'; // '/weeklyreport' 페이지로 이동
+        navigate(`${PATHS.WEEKLY_REPORT.MAIN}?reportId=${reportId}`);
     };
 
     return (

--- a/src/routes/ApiPath.js
+++ b/src/routes/ApiPath.js
@@ -21,7 +21,10 @@ export const SPRING_REPORT_BASE =SPRING_BASE_URL + '/api/reports';
 export const REPORT_CHILD_ALL_REPORT = SPRING_REPORT_BASE + '/all';
 export const REPORT_CHILD_REPORT = SPRING_REPORT_BASE + '/report';
 export const REPORT_CREATE = SPRING_REPORT_BASE + '/create';
-export const REPORT_DELETE = SPRING_REPORT_BASE + '/DELETE';
+export const REPORT_DELETE = SPRING_REPORT_BASE + '/delete';
+export const REPORT_UPDATE = SPRING_REPORT_BASE + '/update';
+
+
 
 
 


### PR DESCRIPTION
- URL의 쿼리 파라미터에서 reportId를 추출하여 해당 보고서를 로드하는 기능 추가
- reportId가 없으면 최신 보고서를 기본으로 선택하도록 로직 수정
- 주간 날짜 범위와 보고서 데이터를 동적으로 업데이트하는 기능 추가
- React Router의 useLocation 훅을 사용하여 쿼리 파라미터 처리
- 이전/다음 보고서로 이동 시 주간 범위와 상태가 업데이트되도록 개선

![화면 캡처 2024-11-11 131408](https://github.com/user-attachments/assets/048ff358-8650-46df-b575-854e13245a9e)
